### PR TITLE
Typo during htop installation

### DIFF
--- a/src/mac-dev-setup.sh
+++ b/src/mac-dev-setup.sh
@@ -65,7 +65,7 @@ brew install tree
 brew install ack
 brew install bash-completion
 brew install jq
-brew intsall htop
+brew install htop
 brew install tldr
 brew install coreutils
 brew install watch


### PR DESCRIPTION
This typo create an error during the installation and is not installing htop
Resolve #18