### PR TITLE
#19: Jetbrains mono powerline is now part of mono

### DIFF
--- a/src/mac-dev-setup.sh
+++ b/src/mac-dev-setup.sh
@@ -78,7 +78,6 @@ brew install ctop
 
 # fonts (https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions)
 brew tap homebrew/cask-fonts
-brew cask install font-jetbrains-mono-powerline
 brew cask install font-jetbrains-mono
 
 # Browser


### PR DESCRIPTION
The cask `font-jetbrains-mono` contains also the `powerline` version. 
The previous package is now disabled.

Resolve #19