### PR TITLE
#17: Give access to zsh folder for zsh-completions

### DIFF
--- a/src/mac-dev-setup.sh
+++ b/src/mac-dev-setup.sh
@@ -39,6 +39,8 @@ git config --global init.templateDir ~/.git-templates/git-secrets
 
 # ZSH
 brew install zsh zsh-completions                                                                      # Install zsh and zsh completions
+sudo chmod -R 755 /usr/local/share/zsh
+sudo chown -R root:staff /usr/local/share/zsh
 {
   echo "if type brew &>/dev/null; then"
   echo "  FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH"


### PR DESCRIPTION
`zsh-completions` does not work and block usage because of a rights problem on `/usr/local/share/zsh`.

See this thread https://stackoverflow.com/questions/13762280/zsh-compinit-insecure-directories to understand what is the problem.

This PR changes the rights and the owner of the folder to be sure that the completions work.

Resolve #17 